### PR TITLE
Add Codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,12 @@
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+*       @merveenoyan @johko @lunarflu
+
+# Order is important; the last matching pattern takes the most
+# precedence. When someone opens a pull request that only
+# modifies files in /chapters/ or /notebooks/, only the here mentioned 
+# and not the global owner(s) will be requested for a review.
+
+/chapters/    @merveenoyan @MKhalusova @NielsRogge
+
+/notebooks/    @merveenoyan @MKhalusova @NielsRogge


### PR DESCRIPTION
At least on of the users mentioned in this codeowners file will need to approve a PR for the respective code they own.

In general I suggest it to be @merveenoyan, @lunarflu and me.

In the case that it is something directly course content related, i.e. something that goes in the _chapters_ or _notebooks_ folder, this is overwritten and one of @merveenoyan, @MKhalusova or @NielsRogge will have to approve a PR.

The main idea is to have this as a quality control check, to make sure we get great content for the course.

I have sparred the idea with @merveenoyan, but of course especiall @MKhalusova and @NielsRogge have to say if they are comfortable with this, as it will probably mean quite some notifications and work, once the content starts coming in.