### PR TITLE
Removed audio from Ethics and Biases unit

### DIFF
--- a/chapters/en/Unit 0 - Welcome/welcome.mdx
+++ b/chapters/en/Unit 0 - Welcome/welcome.mdx
@@ -84,7 +84,7 @@ The course is organized into multiple units, covering the fundamentals and delvi
 - **Unit 9 - Model Optimization** : explore the critical aspects of model optimization. Cover techniques such as model compression, deployment considerations, and the usage of tools and frameworks. Include topics topics like distillation, pruning, and TinyML for efficient model deployment.
 - **Unit 10 - Synthetic Data Creation** : discover the importance of synthetic data creation using deep generative models. Explore methods like point clouds and diffusion models and investigate major synthetic datasets and their applications in computer vision.
 - **Unit 11 - Zero Shot Computer Vision** : delve into the realm of zero-shot learning in computer vision, covering aspects of generalization, transfer learning, and its applications in tasks such as zero-shot recognition and image segmentation. Explore the relationship between zero-shot learning and transfer learning across various computer vision domains.
-- **Unit 12 - Ethics and Biases in Audio and Computer Vision** : understand the ethical considerations specific to computer vision. Explore why ethics matter, how biases can infiltrate AI models, and the types of biases prevalent in these domains. Learn how to do bias evaluation and mitigation strategies, emphasizing responsible development and deployment of AI technologies.
+- **Unit 12 - Ethics and Biases in Computer Vision** : understand the ethical considerations specific to computer vision. Explore why ethics matter, how biases can infiltrate AI models, and the types of biases prevalent in these domains. Learn how to do bias evaluation and mitigation strategies, emphasizing responsible development and deployment of AI technologies.
 - **Unit 13 - Outlook and Emerging Trends** : explore current trends and emerging architectures . Delve into innovative approaches like Retentive Network, Hiera, Hyena, I-JEPA, and Retention Vision Models.
 
 ## Meet our team
@@ -148,7 +148,7 @@ Our goal was to create a computer vision course that is beginner-friendly and th
 - Reviewers: [Ratan Prasad](https://github.com/ratan), [Mohammed Hamdy](https://github.com/mmhamdy), [Albert Kao](https://github.com/albertkao227), [Isabella Bicalho-Frazeto](https://github.com/bellabf)
 - Writers: [Mohammed Hamdy](https://github.com/mmhamdy), [Albert Kao](https://github.com/albertkao227)
 
-**Unit 12 - Ethics and Biases in Audio and Computer Vision**
+**Unit 12 - Ethics and Biases in Computer Vision**
 
 - Reviewers: [Ratan Prasad](https://github.com/ratan), [Mohammed Hamdy](https://github.com/mmhamdy), [Charchit Sharma](https://github.com/charchit7), [Adhi Setiawan](https://github.com/adhiiisetiawan), [Ameed Taylor](https://github.com/atayloraerospace), [Bhavesh Misra](https://github.com/Zekrom-7780)
 - Writers: [Snehil Sanyal](https://github.com/snehilsanyal), [Bhavesh Misra](https://github.com/Zekrom-7780)


### PR DESCRIPTION
This PR removes the word "Audio" from the units reference

fix #232