### PR TITLE
typo in import statement

### DIFF
--- a/chapters/en/unit1/feature-extraction/feature-matching.mdx
+++ b/chapters/en/unit1/feature-extraction/feature-matching.mdx
@@ -15,7 +15,7 @@ First install and load libraries
 ```
 
 ```python
-import cv2 as cv
+import cv2
 import numpy as np
 ```
 
@@ -24,7 +24,7 @@ import numpy as np
 Let's start by initializing SIFT detector.
 
 ```python
-sift = cv.SIFT_create()
+sift = cv2.SIFT_create()
 ```
 
 Find the keypoints and descriptors with SIFT.
@@ -37,7 +37,7 @@ kp2, des2 = sift.detectAndCompute(img2, None)
 Find matches using k nearest neighbors.
 
 ```python
-bf = cv.BFMatcher()
+bf = cv2.BFMatcher()
 matches = bf.knnMatch(des1, des2, k=2)
 ```
 
@@ -53,8 +53,8 @@ for m, n in matches:
 Draw the matches.
 
 ```python
-img3 = cv.drawMatchesKnn(
-    img1, kp1, img2, kp2, good, None, flags=cv.DrawMatchesFlags_NOT_DRAW_SINGLE_POINTS
+img3 = cv2.drawMatchesKnn(
+    img1, kp1, img2, kp2, good, None, flags=cv2.DrawMatchesFlags_NOT_DRAW_SINGLE_POINTS
 )
 ```
 
@@ -67,7 +67,7 @@ img3 = cv.drawMatchesKnn(
 Initialize the ORB descriptor.
 
 ```python
-orb = cv.ORB_create()
+orb = cv2.ORB_create()
 ```
 
 Find keypoints and descriptors.
@@ -81,7 +81,7 @@ Because ORB is a binary descriptor, we find matches using [Hamming Distance](htt
 which is a measure of the difference between two strings of equal length.
 
 ```python
-bf = cv.BFMatcher(cv.NORM_HAMMING, crossCheck=True)
+bf = cv2.BFMatcher(cv2.NORM_HAMMING, crossCheck=True)
 ```
 
 We will now find the matches.
@@ -99,14 +99,14 @@ matches = sorted(matches, key=lambda x: x.distance)
 Draw first n matches.
 
 ```python
-img3 = cv.drawMatches(
+img3 = cv2.drawMatches(
     img1,
     kp1,
     img2,
     kp2,
     matches[:n],
     None,
-    flags=cv.DrawMatchesFlags_NOT_DRAW_SINGLE_POINTS,
+    flags=cv2.DrawMatchesFlags_NOT_DRAW_SINGLE_POINTS,
 )
 ```
 
@@ -140,7 +140,7 @@ search_params = dict(checks=50)
 Initiate SIFT detector
 
 ```python
-sift = cv.SIFT_create()
+sift = cv2.SIFT_create()
 ```
 
 Find the keypoints and descriptors with SIFT
@@ -156,7 +156,7 @@ We will now define the FLANN parameters. Here, trees is the number of bins you w
 FLANN_INDEX_KDTREE = 1
 index_params = dict(algorithm=FLANN_INDEX_KDTREE, trees=5)
 search_params = dict(checks=50)
-flann = cv.FlannBasedMatcher(index_params, search_params)
+flann = cv2.FlannBasedMatcher(index_params, search_params)
 
 matches = flann.knnMatch(des1, des2, k=2)
 ```
@@ -182,10 +182,10 @@ draw_params = dict(
     matchColor=(0, 255, 0),
     singlePointColor=(255, 0, 0),
     matchesMask=matchesMask,
-    flags=cv.DrawMatchesFlags_DEFAULT,
+    flags=cv2.DrawMatchesFlags_DEFAULT,
 )
 
-img3 = cv.drawMatchesKnn(img1, kp1, img2, kp2, matches, None, **draw_params)
+img3 = cv2.drawMatchesKnn(img1, kp1, img2, kp2, matches, None, **draw_params)
 ```
 
 ![FLANN](https://huggingface.co/datasets/hf-vision/course-assets/resolve/main/feature-extraction-feature-matching/FLANN.png)
@@ -207,7 +207,7 @@ We can use [Kornia](https://github.com/kornia/kornia) to find matching features 
 Import the necessary libraries.
 
 ```python
-import cv2 as cv
+import cv2
 import kornia as K
 import kornia.feature as KF
 import matplotlib.pyplot as plt
@@ -255,7 +255,7 @@ Clean up the correspondences using Random Sample Consensus ([RANSAC](https://en.
 ```python
 mkpts0 = correspondences["keypoints0"].cpu().numpy()
 mkpts1 = correspondences["keypoints1"].cpu().numpy()
-Fm, inliers = cv.findFundamentalMat(mkpts0, mkpts1, cv.USAC_MAGSAC, 0.5, 0.999, 100000)
+Fm, inliers = cv2.findFundamentalMat(mkpts0, mkpts1, cv2.USAC_MAGSAC, 0.5, 0.999, 100000)
 inliers = inliers > 0
 ```
 

--- a/chapters/en/unit1/feature-extraction/feature-matching.mdx
+++ b/chapters/en/unit1/feature-extraction/feature-matching.mdx
@@ -15,7 +15,7 @@ First install and load libraries
 ```
 
 ```python
-import cv2
+import cv2 as cv
 import numpy as np
 ```
 
@@ -207,7 +207,7 @@ We can use [Kornia](https://github.com/kornia/kornia) to find matching features 
 Import the necessary libraries.
 
 ```python
-import cv2
+import cv2 as cv
 import kornia as K
 import kornia.feature as KF
 import matplotlib.pyplot as plt
@@ -255,7 +255,7 @@ Clean up the correspondences using Random Sample Consensus ([RANSAC](https://en.
 ```python
 mkpts0 = correspondences["keypoints0"].cpu().numpy()
 mkpts1 = correspondences["keypoints1"].cpu().numpy()
-Fm, inliers = cv2.findFundamentalMat(mkpts0, mkpts1, cv2.USAC_MAGSAC, 0.5, 0.999, 100000)
+Fm, inliers = cv.findFundamentalMat(mkpts0, mkpts1, cv.USAC_MAGSAC, 0.5, 0.999, 100000)
 inliers = inliers > 0
 ```
 


### PR DESCRIPTION
imported as cv2 but used as cv in code snippets. fixed with alias cv instead of making changes everywhere with cv -> cv2.