### PR TITLE
Fix bug in VGG19 implementation

### DIFF
--- a/chapters/en/unit2/cnns/vgg.mdx
+++ b/chapters/en/unit2/cnns/vgg.mdx
@@ -70,6 +70,15 @@ class VGG19(nn.Module):
             nn.Conv2d(512, 512, kernel_size=3, padding=1),
             nn.ReLU(),
             nn.MaxPool2d(kernel_size=2, stride=2),
+            nn.Conv2d(512, 512, kernel_size=3, padding=1),
+            nn.ReLU(),
+            nn.Conv2d(512, 512, kernel_size=3, padding=1),
+            nn.ReLU(),
+            nn.Conv2d(512, 512, kernel_size=3, padding=1),
+            nn.ReLU(),
+            nn.Conv2d(512, 512, kernel_size=3, padding=1),
+            nn.ReLU(),
+            nn.MaxPool2d(kernel_size=2, stride=2),
         )
 
         # Fully connected layers for classification


### PR DESCRIPTION
The implementation of the VGG19 had a bug due to missing convolutional layers, making the classifier input volume shape to be 14x14x512 instead of 7x7x512.

The implemented architecture could be called VGG15 by setting the classifier input layer to `nn.Linear(14x14x512, 4096)`.

I have changed the code to make VGG19 w.r.t the original paper.