### PR TITLE
fix shape mismatch in VGG architecture

### DIFF
--- a/chapters/en/unit2/cnns/vgg.mdx
+++ b/chapters/en/unit2/cnns/vgg.mdx
@@ -76,7 +76,7 @@ class VGG19(nn.Module):
         self.classifier = nn.Sequential(
             nn.Linear(
                 512 * 14 * 14, 4096
-            ),  # 512 channels, 7x7 spatial dimensions after max pooling
+            ),  # 512 channels, 14x14 spatial dimensions after max pooling
             nn.ReLU(),
             nn.Dropout(0.5),  # Dropout layer with 0.5 dropout probability
             nn.Linear(4096, 4096),

--- a/chapters/en/unit2/cnns/vgg.mdx
+++ b/chapters/en/unit2/cnns/vgg.mdx
@@ -75,7 +75,7 @@ class VGG19(nn.Module):
         # Fully connected layers for classification
         self.classifier = nn.Sequential(
             nn.Linear(
-                512 * 7 * 7, 4096
+                512 * 14 * 14, 4096
             ),  # 512 channels, 7x7 spatial dimensions after max pooling
             nn.ReLU(),
             nn.Dropout(0.5),  # Dropout layer with 0.5 dropout probability

--- a/chapters/en/unit2/cnns/vgg.mdx
+++ b/chapters/en/unit2/cnns/vgg.mdx
@@ -70,13 +70,22 @@ class VGG19(nn.Module):
             nn.Conv2d(512, 512, kernel_size=3, padding=1),
             nn.ReLU(),
             nn.MaxPool2d(kernel_size=2, stride=2),
+            nn.Conv2d(512, 512, kernel_size=3, padding=1),
+            nn.ReLU(),
+            nn.Conv2d(512, 512, kernel_size=3, padding=1),
+            nn.ReLU(),
+            nn.Conv2d(512, 512, kernel_size=3, padding=1),
+            nn.ReLU(),
+            nn.Conv2d(512, 512, kernel_size=3, padding=1),
+            nn.ReLU(),
+            nn.MaxPool2d(kernel_size=2, stride=2),
         )
 
         # Fully connected layers for classification
         self.classifier = nn.Sequential(
             nn.Linear(
-                512 * 14 * 14, 4096
-            ),  # 512 channels, 14x14 spatial dimensions after max pooling
+                512 * 7 * 7, 4096
+            ),  # 512 channels, 7x7 spatial dimensions after max pooling
             nn.ReLU(),
             nn.Dropout(0.5),  # Dropout layer with 0.5 dropout probability
             nn.Linear(4096, 4096),

--- a/chapters/en/unit2/cnns/vgg.mdx
+++ b/chapters/en/unit2/cnns/vgg.mdx
@@ -81,6 +81,9 @@ class VGG19(nn.Module):
             nn.MaxPool2d(kernel_size=2, stride=2),
         )
 
+        # Pooling Layer
+        self.avgpool = nn.AdaptiveAvgPool2d(output_size=(7, 7))
+
         # Fully connected layers for classification
         self.classifier = nn.Sequential(
             nn.Linear(
@@ -96,6 +99,7 @@ class VGG19(nn.Module):
 
     def forward(self, x):
         x = self.feature_extractor(x)  # Pass input through the feature extractor layers
+        x = self.avgpool(x) # Pass Data through a pooling layer
         x = x.view(x.size(0), -1)  # Flatten the output for the fully connected layers
         x = self.classifier(x)  # Pass flattened output through the classifier layers
         return x


### PR DESCRIPTION
we should have a `512 * 14 * 14` in here.
and  easy testing script of the architecture could be : 
```python
import torch.nn as nn
import torch

class VGG19(nn.Module):
    def __init__(self, num_classes=1000):
        super(VGG19, self).__init__()

        # Feature extraction layers: Convolutional and pooling layers
        self.feature_extractor = nn.Sequential(
            nn.Conv2d(
                3, 64, kernel_size=3, padding=1
            ),  # 3 input channels, 64 output channels, 3x3 kernel, 1 padding
            nn.ReLU(),
            nn.Conv2d(64, 64, kernel_size=3, padding=1),
            nn.ReLU(),
            nn.MaxPool2d(
                kernel_size=2, stride=2
            ),  # Max pooling with 2x2 kernel and stride 2
            nn.Conv2d(64, 128, kernel_size=3, padding=1),
            nn.ReLU(),
            nn.Conv2d(128, 128, kernel_size=3, padding=1),
            nn.ReLU(),
            nn.MaxPool2d(kernel_size=2, stride=2),
            nn.Conv2d(128, 256, kernel_size=3, padding=1),
            nn.ReLU(),
            nn.Conv2d(256, 256, kernel_size=3, padding=1),
            nn.ReLU(),
            nn.Conv2d(256, 256, kernel_size=3, padding=1),
            nn.ReLU(),
            nn.Conv2d(256, 256, kernel_size=3, padding=1),
            nn.ReLU(),
            nn.MaxPool2d(kernel_size=2, stride=2),
            nn.Conv2d(256, 512, kernel_size=3, padding=1),
            nn.ReLU(),
            nn.Conv2d(512, 512, kernel_size=3, padding=1),
            nn.ReLU(),
            nn.Conv2d(512, 512, kernel_size=3, padding=1),
            nn.ReLU(),
            nn.Conv2d(512, 512, kernel_size=3, padding=1),
            nn.ReLU(),
            nn.MaxPool2d(kernel_size=2, stride=2),
        )

        # Fully connected layers for classification
        self.classifier = nn.Sequential(
            nn.Linear(
                512 * 14 * 14, 4096
            ),  # 512 channels, 7x7 spatial dimensions after max pooling
            nn.ReLU(),
            nn.Dropout(0.5),  # Dropout layer with 0.5 dropout probability
            nn.Linear(4096, 4096),
            nn.ReLU(),
            nn.Dropout(0.5),
            nn.Linear(4096, num_classes),  # Output layer with 'num_classes' output units
        )

    def forward(self, x):
        x = self.feature_extractor(x)  # Pass input through the feature extractor layers
        x = x.view(x.size(0), -1)  # Flatten the output for the fully connected layers
        x = self.classifier(x)  # Pass flattened output through the classifier layers
        return x

t = torch.ones(1, 3, 224, 224, dtype=torch.float)
model = VGG19()
model(t)
```