### PR TITLE
Correct Typographical Error in Vision Transformer Introduction

### DIFF
--- a/chapters/en/unit3/vision-transformers/vision-transformers-for-image-classification.mdx
+++ b/chapters/en/unit3/vision-transformers/vision-transformers-for-image-classification.mdx
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-As the Transformers architecture scaled well in Natural Language Processing, the same architecture was applied to images by creating small patches of the image and treating them as tokens. The result was a Vision Transformer (Vision Transformers). Before we get started with transfer learning / fine-tuning concepts, let's compare Convolutional Neural Networks (CNNs) with Vision Transformers.
+As the Transformers architecture scaled well in Natural Language Processing, the same architecture was applied to images by creating small patches of the image and treating them as tokens. The result was a Vision Transformer (ViT). Before we get started with transfer learning / fine-tuning concepts, let's compare Convolutional Neural Networks (CNNs) with Vision Transformers.
 
 ### CNN vs Vision Transformers: Inductive Bias
 


### PR DESCRIPTION
This pull request addresses a minor typographical error in the introduction section of the document titled "Transfer Learning and Fine-tuning Vision Transformers for Image Classification."

**Issue:**
The current text includes a redundant repetition:
"The result was a Vision Transformer (Vision Transformers)."

**Fix:**
The text is corrected to:
"The result was a Vision Transformer (ViT)."