### PR TITLE
add style target to makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,6 @@
 quality:
 	python utils/code_formatter.py --check_only
 
-# Format code samples automatically and check is there are any problems left that need manual fixing
+# Format code samples automatically and check if there are any problems left that need manual fixing
 style:
 	python utils/code_formatter.py

--- a/Makefile
+++ b/Makefile
@@ -3,3 +3,7 @@
 # Check code formatting
 quality:
 	python utils/code_formatter.py --check_only
+
+# Format code samples automatically and check is there are any problems left that need manual fixing
+style:
+	python utils/code_formatter.py

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: quality
-
+.PHONY: quality style
 # Check code formatting
 quality:
 	python utils/code_formatter.py --check_only

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-.PHONY: quality
 .PHONY: quality style
+
 # Check code formatting
 quality:
 	python utils/code_formatter.py --check_only

--- a/chapters/en/unit2/cnns/vgg.mdx
+++ b/chapters/en/unit2/cnns/vgg.mdx
@@ -99,7 +99,7 @@ class VGG19(nn.Module):
 
     def forward(self, x):
         x = self.feature_extractor(x)  # Pass input through the feature extractor layers
-        x = self.avgpool(x) # Pass Data through a pooling layer
+        x = self.avgpool(x)  # Pass Data through a pooling layer
         x = x.view(x.size(0), -1)  # Flatten the output for the fully connected layers
         x = self.classifier(x)  # Pass flattened output through the classifier layers
         return x


### PR DESCRIPTION
Added the `style`  target to the makefile, so you actually can run `make style` to fix formatting. 
(command shamelessly copied from the audio course https://github.com/huggingface/audio-transformers-course/blob/main/Makefile )