### PR TITLE
Updated Maths to correct rendering

### DIFF
--- a/chapters/en/unit5/generative-models/variational_autoencoders.mdx
+++ b/chapters/en/unit5/generative-models/variational_autoencoders.mdx
@@ -7,9 +7,14 @@ Autoencoders are a class of neural networks primarily used for unsupervised lear
 
 ![Vanilla Autoencoder Image - Lilian Weng Blog](https://huggingface.co/datasets/hf-vision/course-assets/resolve/main/generative_models/autoencoder.png)
 
-This encoder model consists of an encoder network (represented as \\(g_\phi\\)) and a decoder network (represented as \\(f_\theta\\)). The low-dimensional representation is learned in the bottleneck layer as \\(z\\) and the reconstructed output is represented as \\(x' = f_\theta(g_\phi(x))\\) with the goal of \\(x \approx x'\\).
+This encoder model consists of an encoder network (represented as $g_\phi$) and a decoder network (represented as $f_\theta$). The low-dimensional representation is learned in the bottleneck layer as $z$, and the reconstructed output is represented as $x' = f_\theta(g_\phi(x))$ with the goal of $x \approx x'$.
 
-A common loss function used in such vanilla autoencoders is \\(L(\theta, \phi) = \frac{1}{n}\sum_{i=1}^n (\mathbf{x}^{(i)} - f_\theta(g_\phi(\mathbf{x}^{(i)})))^2\\), which tries to minimize the error between the original image and the reconstructed one and is also known as the `reconstruction loss`.
+A common loss function used in such vanilla autoencoders is 
+
+$$L(\theta, \phi) = \frac{1}{n}\sum_{i=1}^n (\mathbf{x}^{(i)} - f_\theta(g_\phi(\mathbf{x}^{(i)})))^2$$ 
+
+which tries to minimize the error between the original image and the reconstructed one. This is also known as the `reconstruction loss`.
+
 
 Autoencoders are useful for tasks such as data denoising, feature learning, and compression. However, traditional autoencoders lack the probabilistic nature that makes VAEs particularly intriguing and also useful for generational tasks.
 


### PR DESCRIPTION
### Fix Math Rendering in Documentation in [Unit 5](https://huggingface.co/learn/computer-vision-course/en/unit5/generative-models/variational_autoencoders) (Issue #315)

This PR addresses issue #315 by updating the math equations in the documentation to work with GitHub's Markdown renderer. 

- Replaced LaTeX-style `\\( ... \\)` with `$ ... $` for inline math.
- Converted block-level equations to `$$ ... $$`.

This ensures the math displays correctly on GitHub.
